### PR TITLE
Rework texture handling

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -105,7 +105,7 @@ impl<'a> GameLogic for Logic<'a> {
     fn render(&self, mut r_args: RenderArgs){
         //.rotate() doesn't actually work properly right now
         r_args.draw_drawables()
-            .append(&self.objects)
+            .add_vec(&self.objects)
             .draw()
             .unwrap_or_else(|e| panic!("{}", e))
     }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -111,8 +111,7 @@ pub struct Draw<'a> {
     display: GlutinFacade,
     program: Program,
     indices: NoIndices,
-    params : DrawParameters<'a>,
-    halfsize: (f32, f32)
+    params : DrawParameters<'a>
 }
 
 impl<'a> Draw<'a> {
@@ -178,21 +177,21 @@ impl<'a> Draw<'a> {
             indices: NoIndices(glium::index::PrimitiveType::TrianglesList),
             display: display,
             params : params,
-            halfsize: (w, h),
+            // halfsize: (w, h),
         }
     }
 
-    /// Loads a texture from a byte slice into the texture cache
+    /// Returns a `Texture` created from a byte slice
     pub fn load_texture_from_bytes(&self, bytes: &[u8], width: u32, height: u32) -> Result<Texture> {
         Texture::new(&self.display, bytes, width, height)
     }
 
-    /// Loads a texture from a file into the texture cache
+    /// Returns a `Texture` created from a file
     pub fn load_texture(&self, identifier: &'a str, width: u32, height: u32) -> Result<Texture> {
         Texture::new_from_file(&self.display, &format!("{}.png", identifier), width, height)
     }
 
-    /// Draws a slice of `Drawable`s to the screen
+    /// Returns a `DrawablesDrawer` for drawing `Drawable`s to the screen
     pub fn draw_drawables<D: Drawable>(&'a self, target: &'a mut glium::Frame) -> DrawablesDrawer<D>{
         DrawablesDrawer{
             drawables: Vec::new(),
@@ -201,18 +200,13 @@ impl<'a> Draw<'a> {
         }
     }
 
-    /// Returns the size of the window
-    pub fn get_halfsize(&self) -> (f32, f32) {
-        self.halfsize
-    }
-
     /// Returns the inner `GlutinFacade`
     pub fn get_display(&self) -> &GlutinFacade {
         &self.display
     }
 }
 
-/// An interface for drawing a `Drawable`s on the screen
+/// An interface for drawing `Drawable`s on the screen
 #[must_use = "`DrawablesDrawer` does nothing until drawn"]
 pub struct DrawablesDrawer<'a, D: 'a + Drawable>{
     drawables: Vec<&'a D>,
@@ -228,8 +222,8 @@ impl<'a, D: Drawable> DrawablesDrawer<'a, D>{
         self
     }
 
-    /// Appends a vector of `Drawable`s to the inner vector
-    pub fn append<I: IntoIterator<Item = &'a D>>(mut self, drawables: I) -> Self{
+    /// Adds an `Iterator` of `Drawable`s to be drawn
+    pub fn add_vec<I: IntoIterator<Item = &'a D>>(mut self, drawables: I) -> Self{
         for d in drawables.into_iter(){
             self = self.add(d);
         }
@@ -263,7 +257,7 @@ pub struct TextureDrawer<'a> {
 }
 
 impl<'a> TextureDrawer<'a> {
-    /// Rotates the texture, though it seems in a bit of a skewed manner
+    /// Rotates the texture
     pub fn rotate(self, rotation: f32) -> TextureDrawer<'a> {
         TextureDrawer{
             rotation: rotation,
@@ -272,7 +266,7 @@ impl<'a> TextureDrawer<'a> {
         }
     }
 
-    /// Translates the texture on the screen
+    /// Translates the texture
     pub fn translate(self, translate_x: f32, translate_y: f32) -> TextureDrawer<'a> {
         TextureDrawer{
             translation: (translate_x, translate_y),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub const VERSION: &'static str = include_str!("../version.txt");
 pub type Result<T> = std::result::Result<T, KoromeError>;
 
 quick_error! {
-    /// Describes errors that can occur in this crate
+    /// Wraps together errors that can occur in this crate
     #[derive(Debug)]
     pub enum KoromeError{
         /// A `glium::DrawError`
@@ -76,7 +76,7 @@ quick_error! {
 pub struct LogicArgs<'a>{
     /// The delta time since last frame
     delta    : f64,
-    /// A vector of all key events that happpened
+    /// A vector of all key events that happened
     keyevents: &'a [(bool, u8)],
     /// A `HashSet` of all keys that are pressed down
     down_keys: &'a HashSet<u8>,
@@ -85,7 +85,7 @@ pub struct LogicArgs<'a>{
 }
 
 impl<'a> LogicArgs<'a>{
-    /// Returns the delta value of the InfoPacket
+    /// Returns the delta time
     pub fn delta(&self) -> f64{
         self.delta
     }
@@ -123,7 +123,7 @@ impl<'a> RenderArgs<'a>{
         self.draw
     }
 
-    /// Draws a slice of `Drawable`s to the screen using `Draw::texture()`
+    /// Returns a `DrawablesDrawer` for drawing `Drawable`s to the screen
     pub fn draw_drawables<D: Drawable>(&mut self) -> DrawablesDrawer<D>{
         self.draw.draw_drawables(self.target)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub use draw::Draw;
 pub use vector::Vector2;
 pub use settings::Settings;
 
-use draw::Drawable;
+use draw::{Drawable, DrawablesDrawer};
 
 use glium::{Frame, Surface};
 use glium::glutin::{Event, ElementState, /*VirtualKeyCode*/};
@@ -40,10 +40,6 @@ quick_error! {
     /// Describes errors that can occur in this crate
     #[derive(Debug)]
     pub enum KoromeError{
-        /// Texture wasn't found in cache
-        TextureNotFound {
-            display("The Texture with the given identifier didn't exist in the cache.")
-        }
         /// A `glium::DrawError`
         DrawError(err: glium::DrawError){
             from()
@@ -128,8 +124,8 @@ impl<'a> RenderArgs<'a>{
     }
 
     /// Draws a slice of `Drawable`s to the screen using `Draw::texture()`
-    pub fn draw_drawables<D: Drawable>(&mut self, drawables: &[D]) -> Result<()>{
-        self.draw.draw_drawables(self.target, drawables)
+    pub fn draw_drawables<D: Drawable>(&mut self) -> DrawablesDrawer<D>{
+        self.draw.draw_drawables(self.target)
     }
 }
 


### PR DESCRIPTION
Remove cache from `Draw`
Make `Texture` public
Rework `Drawable` for new texture handling
Add new `DrawablesDrawer` for drawing `Drawables` similar to `TextureDrawer`
Adjust example basic.rs for the changes

The documentation will also have to be updated for this.
