### PR TITLE
Rework struct `Game`

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,13 +2,12 @@ extern crate glium;
 #[macro_use]
 extern crate korome;
 
-use korome::{Game, Draw, LogicArgs, RenderArgs, Vector2};
-use korome::draw::{Drawable, Texture};
+use korome::*;
 
 fn main() {
-    let draw = Draw::new("glium works!", 800, 600);
+    let draw = Draw::new("korome works!", 800, 600);
 
-    let planet = draw.load_texture_from_bytes(include_bytes!("planet.png"), 64, 64).unwrap();
+    let planet = include_texture!(draw, "planet.png", 64, 64).unwrap();
 
     let mut objs = Vec::new();
 
@@ -83,8 +82,6 @@ fn logic(objs: &mut Vec<Object>, l_args: LogicArgs){
 
 fn render(objs: &Vec<Object>, mut r_args: RenderArgs){
     //.rotate() doesn't actually work properly right now
-    r_args.draw_drawables()
-        .add_vec(objs)
-        .draw()
+    r_args.draw_drawables(objs)
         .unwrap_or_else(|e| panic!("{}", e))
 }

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -34,7 +34,7 @@ impl<'a> Object<'a>{
     }
 }
 
-impl<'a> Drawable for Object<'a>{
+impl<'a> Sprite for Object<'a>{
     fn get_pos(&self) -> (f32, f32){
         self.pos.into()
     }
@@ -82,6 +82,6 @@ fn logic(objs: &mut Vec<Object>, l_args: LogicArgs){
 
 fn render(objs: &Vec<Object>, mut r_args: RenderArgs){
     //.rotate() doesn't actually work properly right now
-    r_args.draw_drawables(objs)
+    r_args.draw_sprites(objs)
         .unwrap_or_else(|e| panic!("{}", e))
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate korome;
+
+use korome::*;
+
+fn main() {
+    // Create a draw object, which creates a window with the given title and dimensions
+    let draw = Draw::new("Just a single static texture", 800, 600);
+
+    // Load a texture, whose bytes have been loaded at compile-time with the given dimensions
+    let texture = include_texture!(draw, "planet.png", 64, 64).unwrap();
+
+    // Create a game object with an empty logic function
+    // and a render function that draws the texture unrotatedly in the middle of the window
+    let game = Game::new(draw, |_, _| {}, |_, mut args|{
+        args.draw_texture(&texture, 0., 0., 0.).unwrap();
+    });
+
+    // Run the game until the window is closed.
+    game.run_until_closed();
+}

--- a/src/bin/size_info.rs
+++ b/src/bin/size_info.rs
@@ -2,7 +2,6 @@ extern crate korome;
 extern crate glium;
 
 use korome::*;
-use korome::draw::{Texture, TextureDrawer};
 
 use glium::texture::Texture2d;
 
@@ -14,10 +13,13 @@ macro_rules! print_type_info{
             use std::mem::{align_of, size_of};
 
             let (size, align) = (size_of::<$t>(), align_of::<$t>());
-            println!("{}\t: {} === {} * {}", stringify!($t), size, size/align, align);
+            println!("{}\t: {} <= {} * {}", stringify!($t), size, size/align, align);
         })*
     }
 }
+
+type LogicFn = fn(&mut(), LogicArgs);
+type RenderFn = fn(&(), RenderArgs);
 
 fn main(){
     println!("Version: {}", korome::VERSION);
@@ -32,6 +34,8 @@ fn main(){
         Vector2<f32>
         Vector2<f64>
         GlutinFacade
-        TextureDrawer
+        fn(&(), RenderArgs)
+        fn(&mut (), LogicArgs)
+        Game<(), LogicFn, RenderFn>
     );
 }

--- a/src/bin/size_info.rs
+++ b/src/bin/size_info.rs
@@ -1,7 +1,7 @@
 extern crate korome;
 extern crate glium;
 
-use korome::{Draw, Vector2, Game, Settings, LogicArgs, RenderArgs, GameLogic};
+use korome::*;
 use korome::draw::{Texture, TextureDrawer};
 
 use glium::texture::Texture2d;
@@ -9,12 +9,12 @@ use glium::texture::Texture2d;
 use glium::backend::glutin_backend::GlutinFacade;
 
 macro_rules! print_type_info{
-    ($($t:ty),*) => {
+    ($($t:ty)*) => {
         $({
             use std::mem::{align_of, size_of};
 
-            let info = (size_of::<$t>(), align_of::<$t>());
-            println!("{}\t: {} === {} * {}", stringify!($t), info.0, info.0/info.1, info.1);
+            let (size, align) = (size_of::<$t>(), align_of::<$t>());
+            println!("{}\t: {} === {} * {}", stringify!($t), size, size/align, align);
         })*
     }
 }
@@ -22,17 +22,16 @@ macro_rules! print_type_info{
 fn main(){
     println!("Version: {}", korome::VERSION);
 
-    print_type_info!(Logic, Draw, Texture, Vector2<f32>, Vector2<f64>, Game<Logic>, LogicArgs, RenderArgs, Settings, Texture2d, TextureDrawer, GlutinFacade);
-}
-
-struct Logic;
-
-impl GameLogic for Logic {
-    fn logic (&mut self, _: LogicArgs){
-
-    }
-
-    fn render(&self, _: RenderArgs){
-
-    }
+    print_type_info!(
+        Draw
+        Texture
+        Settings
+        Texture2d
+        LogicArgs
+        RenderArgs
+        Vector2<f32>
+        Vector2<f64>
+        GlutinFacade
+        TextureDrawer
+    );
 }

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -1,8 +1,6 @@
 extern crate glium;
 extern crate image;
 
-use std::collections::HashMap;
-
 use glium::{DisplayBuild, VertexBuffer, Program, DrawParameters, Surface};
 use glium::backend::glutin_backend::GlutinFacade;
 use glium::texture::Texture2d;
@@ -82,26 +80,6 @@ macro_rules! include_texture {
     };
 }
 
-/*
-const INDENTIY_MATRIX: [[f32; 4]; 4] = [
-    [1.0, 0.0, 0.0, 0.0],
-    [0.0, 1.0, 0.0, 0.0],
-    [0.0, 0.0, 1.0, 0.0],
-    [0.0, 0.0, 0.0, 1.0]];
-*/
-
-type Textures<'a> = HashMap<&'a str, Texture>;
-
-/// Trait for objects that can be drawn to the screen
-pub trait Drawable {
-    /// Returns the position on the screen it should be drawn
-    fn get_pos(&self) -> (f32, f32);
-    /// Returns the rotation it should be drawn with
-    fn get_rotation(&self) -> f32;
-    /// Returns the `Texture`
-    fn get_texture(&self) -> &Texture;
-}
-
 /// Functionality for rendering
 pub struct Draw<'a> {
     display: GlutinFacade,
@@ -114,7 +92,7 @@ const INDICES: NoIndices = NoIndices(glium::index::PrimitiveType::TrianglesList)
 impl<'a> Draw<'a> {
     /// Creates a new `Draw` from a `Display` made using the arguments
     pub fn new(title: &str, width: u32, height: u32) -> Draw<'a> {
-        Self::new_from_display(
+        Self::from_display(
             glium::glutin::WindowBuilder::new()
                 .with_title(title.to_string())
                 .with_dimensions(width, height)
@@ -124,7 +102,7 @@ impl<'a> Draw<'a> {
     }
 
     /// Creates a new `Draw` instance using the given display
-    pub fn new_from_display(display: GlutinFacade) -> Draw<'a> {
+    pub fn from_display(display: GlutinFacade) -> Draw<'a> {
         let (w, h) = display.get_window().unwrap().get_inner_size().unwrap();
         let (w, h) = (w as f32 / 2.0, h as f32 / 2.0);
 
@@ -182,20 +160,6 @@ impl<'a> Draw<'a> {
     /// Returns a `Texture` created from a file
     pub fn load_texture(&self, identifier: &'a str, width: u32, height: u32) -> Result<Texture> {
         Texture::new_from_file(&self.display, &format!("{}.png", identifier), width, height)
-    }
-
-    /// Draws an iterator of `Drawable`s onto the screen
-    pub fn draw_drawables<'d, D: 'd + Drawable, I: IntoIterator<Item = &'d D>>(&self, target: &mut glium::Frame, drawables: I) -> Result<()>{
-        for drawable in drawables{
-            let (x, y) = drawable.get_pos();
-
-            try!(
-                self.draw_texture(target, drawable.get_texture(),
-                    drawable.get_rotation(), x, y)
-            );
-        }
-
-        Ok(())
     }
 
     /// Draws a texture onto the screen

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -74,10 +74,11 @@ impl Texture {
     }
 }
 
+/// Loads a texture, by loading the bytes at compile-time
 #[macro_export]
 macro_rules! include_texture {
-    ($draw:expr, $texture:tt, $w:expr, $h:expr) => {
-        $draw.load_texture_from_bytes(include_bytes!($texture), $w, $h)
+    ($draw:expr, $texture:tt, $width:expr, $height:expr) => {
+        $draw.load_texture_from_bytes(include_bytes!($texture), $width, $height)
     };
 }
 

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -31,7 +31,7 @@ impl Vertex{
 
 type VertexBuffers = [VertexBuffer<Vertex>; 2];
 
-/// Struct for storing a 2D texture
+/// A 2D texture that is ready to be drawn
 // NOTE Size: 1 696 bytes
 pub struct Texture{
     tex: Texture2d,
@@ -80,7 +80,7 @@ macro_rules! include_texture {
     };
 }
 
-/// Functionality for rendering
+/// Contains the display and handles most of the graphics
 pub struct Draw<'a> {
     display: GlutinFacade,
     program: Program,

--- a/src/draw.rs
+++ b/src/draw.rs
@@ -73,11 +73,6 @@ impl Texture {
         Self::new(display, &bytes, width, height)
     }
 
-    /// Gets the array of `VertexBuffer`s
-    fn get_vertex_bufffers(&self) -> &VertexBuffers {
-        &self.vertex_buffers
-    }
-
     /// Returns a `TextureDrawer` to draw the `Texture1`
     pub fn drawer(&self) -> TextureDrawer{
         TextureDrawer{
@@ -86,6 +81,13 @@ impl Texture {
             translation: (0.0, 0.0),
         }
     }
+}
+
+#[macro_export]
+macro_rules! include_texture {
+    ($draw:expr, $texture:tt, $w:expr, $h:expr) => {
+        $draw.load_texture_from_bytes(include_bytes!($texture), $w, $h)
+    };
 }
 
 /*
@@ -289,7 +291,7 @@ impl<'a> TextureDrawer<'a> {
             ],
         };
 
-        for vertex_buffer in self.texture.get_vertex_bufffers(){
+        for vertex_buffer in &self.texture.vertex_buffers{
             try!(frame.draw(vertex_buffer, &draw.indices, &draw.program, &uniforms, &draw.params));
         }
 

--- a/src/game.rs
+++ b/src/game.rs
@@ -88,7 +88,7 @@ impl<'a, S, L, R> Game<'a, S, L, R> where L: FnMut(&mut S, LogicArgs), R: FnMut(
     }
 }
 
-/// Wraps all useful info about what has happened (e.g. events) together
+/// Wraps together useful data about what has happened (e.g. events)
 #[derive(Debug)]
 pub struct LogicArgs<'a>{
     /// The time that has passed since last update
@@ -109,7 +109,8 @@ impl<'a> LogicArgs<'a>{
     }
 }
 
-/// Wraps together everything needed to render
+/// Wraps together everything needed to render and
+/// also provides functions for actually drawing
 pub struct RenderArgs<'a>{
     /// Object used to draw on the buffer.
     /// Generally, you shouldn't have to access this directly.

--- a/src/game.rs
+++ b/src/game.rs
@@ -1,0 +1,187 @@
+extern crate glium;
+extern crate time;
+
+use std::collections::HashSet;
+
+use super::{Result, Draw, Drawable, Texture};
+use time::precise_time_s as time_s;
+
+use glium::{Frame, Surface};
+use glium::glutin::{Event, ElementState, VirtualKeyCode};
+
+/// A struct to keep your "game" in
+pub struct Game<'a, S, L, R>  where L: FnMut(&mut S, LogicArgs), R: FnMut(&S, RenderArgs){
+    /// An object that will parsed into the logic and render methods
+    pub shared: S,
+    logic : L,
+    render: R,
+    draw  : Draw<'a>,
+}
+
+impl<'a, S, L, R> Game<'a, S, L, R> where L: FnMut(&mut S, LogicArgs), R: FnMut(&S, RenderArgs){
+    /// Creates a new `Game` with a `Draw` and two closures
+    pub fn new(draw: Draw<'a>, logic: L, render: R) -> Game<'a, (), L, R>
+    where L: FnMut(&mut (), LogicArgs), R: FnMut(&(), RenderArgs){
+        Game{
+            shared: (),
+            logic : logic,
+            render: render,
+            draw  : draw,
+        }
+    }
+
+    /// Creates a new `Game` with a `Draw`, a shared value, and two closures
+    pub fn with_shared(draw: Draw<'a>, shared: S, logic: L, render: R) -> Self{
+        Game{
+            shared: shared,
+            logic : logic,
+            render: render,
+            draw  : draw,
+        }
+    }
+
+    /// Runs the `Game` until the window is closed
+    pub fn run_until_closed(mut self){
+        let mut last = time_s();
+        let mut down_keys: HashSet<VirtualKeyCode> = HashSet::new();
+        let mut mousepos = (0, 0);
+
+        'main: loop {
+            let mut keys = Vec::new();
+
+            for ev in self.draw.get_display().poll_events() {
+                match ev {
+                    Event::Closed => break 'main,
+                    Event::KeyboardInput(es, _, vkc) => match es{
+                        ElementState::Pressed  => {
+                            if let Some(vkc) = vkc{
+                                down_keys.insert( vkc);
+                                keys.push((true , vkc));
+                            }
+                        },
+                        ElementState::Released => {
+                            if let Some(vkc) = vkc{
+                                down_keys.remove(&vkc);
+                                keys.push((false, vkc));
+                            }
+                        }
+                    },
+                    Event::MouseMoved(pos) => mousepos = pos,
+                    _ => ()
+                }
+            }
+
+            let now = time_s();
+
+            let delta = now-last;
+
+            last = now;
+
+            (self.logic)(&mut self.shared, LogicArgs{
+                delta    :  delta,
+                keyevents: &keys,
+                down_keys: &down_keys,
+                mousepos :  mousepos
+            });
+
+            // Do rendering
+            let mut target = self.draw.get_display().draw();
+            target.clear_color(0.0, 0.0, 1.0, 1.0);
+
+            (self.render)(&self.shared, RenderArgs{
+                target: &mut target,
+                draw  : &self.draw
+            });
+
+            target.finish().unwrap()
+        }
+    }
+}
+
+/// Wraps all useful info about what has happened (e.g. events) together
+#[derive(Debug)]
+pub struct LogicArgs<'a>{
+    /// The delta time since last frame
+    pub delta    : f64,
+    /// The current position of the mouse
+    pub mousepos : (i32, i32),
+    /// A vector of all key events that happened
+    pub keyevents: &'a [(bool, VirtualKeyCode)],
+
+    /// A `HashSet` of all keys that are pressed down
+    down_keys: &'a HashSet<VirtualKeyCode>
+}
+
+impl<'a> LogicArgs<'a>{
+    /// Checks whether a key is pressed down
+    pub fn is_down(&self, key: &VirtualKeyCode) -> bool{
+        self.down_keys.contains(key)
+    }
+}
+
+use std::ops::Deref;
+
+/// Wraps everything needed to render together
+pub struct RenderArgs<'a>{
+    /// Object used to draw on the buffer.
+    /// Generally, you shouldn't have to access this directly.
+    pub target: &'a mut glium::Frame,
+    /// Reference to the `Draw` instance
+    /// Generally, you shouldn't have to access this directly.
+    pub draw  : &'a Draw<'a>
+}
+
+impl<'a> RenderArgs<'a>{
+    /// Uses `Draw` to draw an iterator of `Drawable`s onto the screen
+    pub fn draw_drawables<'d, D: 'd + Drawable, I: IntoIterator<Item = &'d D>>(&mut self, drawables: I) -> Result<()>{
+        self.draw.draw_drawables(self.target, drawables)
+    }
+
+    /// Uses `Draw` to draw a texture onto the screen
+    pub fn draw_texture(&mut self, texture: &Texture, rotation: f32, x: f32, y: f32) -> Result<()>{
+        self.draw.draw_texture(self.target, texture, rotation, x, y)
+    }
+}
+
+impl<'a> Deref for RenderArgs<'a>{
+    type Target = Draw<'a>;
+
+    fn deref(&self) -> &Draw<'a>{
+        self.draw
+    }
+}
+
+/// Macro for easily doing things if particular keys are down
+/// # Examples
+/// Basic usage:
+///
+/// ```ignore
+/// #[macro_use]
+/// extern crate korome;
+///
+/// use korome::{GameLogic, LogicArgs};
+///
+/// struct Logic {
+///     player_y: f32
+/// }
+///
+/// impl GameLogic for Logic{
+///     fn logic(&self, l_args: LogicArgs){
+///         is_down!(l_args;
+///             W, Up => {
+///                 self.player_y -= l_args.delta() as f32
+///             },
+///             S, Down => {
+///                 self.player_y += l_args.delta() as f32
+///             }
+///         );
+///     }
+///     // the rest of implementation omitted
+/// }
+/// ```
+#[macro_export]
+macro_rules! is_down{
+    ( $l_args:ident; $( $( $key:ident ),+ => $b:block ),+ ) => {{
+        $( if $( $l_args.is_down(&glium::glutin::VirtualKeyCode::$key) )||+ $b )+
+    }}
+}

--- a/src/game.rs
+++ b/src/game.rs
@@ -3,7 +3,7 @@ extern crate time;
 
 use std::collections::HashSet;
 
-use super::{Result, Draw, Drawable, Texture};
+use super::{Result, Draw, Texture};
 use time::precise_time_s as time_s;
 
 use glium::{Frame, Surface};
@@ -114,21 +114,40 @@ pub struct RenderArgs<'a>{
     /// Object used to draw on the buffer.
     /// Generally, you shouldn't have to access this directly.
     pub target: &'a mut glium::Frame,
-    /// Reference to the `Draw` instance
+    /// Reference to the `Draw` instance.
     /// Generally, you shouldn't have to access this directly.
     pub draw  : &'a Draw<'a>
 }
 
 impl<'a> RenderArgs<'a>{
-    /// Uses `Draw` to draw an iterator of `Drawable`s onto the screen
-    pub fn draw_drawables<'d, D: 'd + Drawable, I: IntoIterator<Item = &'d D>>(&mut self, drawables: I) -> Result<()>{
-        self.draw.draw_drawables(self.target, drawables)
-    }
-
     /// Uses `Draw` to draw a texture onto the screen
     pub fn draw_texture(&mut self, texture: &Texture, rotation: f32, x: f32, y: f32) -> Result<()>{
         self.draw.draw_texture(self.target, texture, rotation, x, y)
     }
+
+    /// Draws an iterator of `Sprite`s onto the screen
+    pub fn draw_sprites<'b, D: 'b + Sprite, I: IntoIterator<Item = &'b D>>(&mut self, sprites: I) -> Result<()>{
+        for sprite in sprites{
+            let (x, y) = sprite.get_pos();
+
+            try!(
+                self.draw_texture(sprite.get_texture(),
+                sprite.get_rotation(), x, y)
+            );
+        }
+
+        Ok(())
+    }
+}
+
+/// Descibes objects that can be drawn to the screen
+pub trait Sprite {
+    /// Returns the position on the screen it should be drawn
+    fn get_pos(&self) -> (f32, f32);
+    /// Returns the rotation it should be drawn with
+    fn get_rotation(&self) -> f32;
+    /// Returns the `Texture`
+    fn get_texture(&self) -> &Texture;
 }
 
 /// Macro for easily doing things if particular keys are down

--- a/src/game.rs
+++ b/src/game.rs
@@ -52,18 +52,14 @@ impl<'a, S, L, R> Game<'a, S, L, R> where L: FnMut(&mut S, LogicArgs), R: FnMut(
             for ev in self.draw.get_display().poll_events() {
                 match ev {
                     Event::Closed => break 'main,
-                    Event::KeyboardInput(es, _, vkc) => match es{
+                    Event::KeyboardInput(es, _, Some(vkc)) => match es{
                         ElementState::Pressed  => {
-                            if let Some(vkc) = vkc{
-                                down_keys.insert( vkc);
-                                keys.push((true , vkc));
-                            }
+                            down_keys.insert( vkc);
+                            keys.push((true , vkc));
                         },
                         ElementState::Released => {
-                            if let Some(vkc) = vkc{
-                                down_keys.remove(&vkc);
-                                keys.push((false, vkc));
-                            }
+                            down_keys.remove(&vkc);
+                            keys.push((false, vkc));
                         }
                     },
                     Event::MouseMoved(pos) => mousepos = pos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,26 +9,15 @@ extern crate toml;
 #[macro_use]
 extern crate quick_error;
 
-/// Provides all rendering functionality
-pub mod draw;
-
+mod draw;
+mod game;
 mod vector;
 mod settings;
 
-pub use draw::Draw;
+pub use draw::{Draw, Texture, Drawable};
+pub use game::{Game, LogicArgs, RenderArgs};
 pub use vector::{Vector2, FloatVector};
 pub use settings::Settings;
-
-use draw::{Drawable, DrawablesDrawer};
-
-use glium::{Frame, Surface};
-use glium::glutin::{Event, ElementState, VirtualKeyCode};
-use glium::texture::*;
-
-use time::precise_time_s as time_s;
-
-use std::error::Error;
-use std::collections::HashSet;
 
 /// Current engine version
 pub const VERSION: &'static str = include_str!(concat!(env!("OUT_DIR"), "/version"));
@@ -67,168 +56,6 @@ quick_error! {
             from()
             cause(err)
             description(err.description())
-        }
-    }
-}
-
-/// Wraps all useful info about what has happened (e.g. events) together
-#[derive(Debug)]
-pub struct LogicArgs<'a>{
-    /// The delta time since last frame
-    pub delta    : f64,
-    /// The current position of the mouse
-    pub mousepos : (i32, i32),
-    /// A vector of all key events that happened
-    pub keyevents: &'a [(bool, VirtualKeyCode)],
-
-    /// A `HashSet` of all keys that are pressed down
-    down_keys: &'a HashSet<VirtualKeyCode>
-}
-
-impl<'a> LogicArgs<'a>{
-    /// Checks whether a key is pressed down
-    pub fn is_down(&self, key: &VirtualKeyCode) -> bool{
-        self.down_keys.contains(key)
-    }
-}
-
-/// Wraps everything needed to render together
-pub struct RenderArgs<'a>{
-    /// Object used to draw on the buffer.
-    /// Generally, you shouldn't have to access this directly.
-    pub target: &'a mut glium::Frame,
-    /// Reference to the `Draw` instance
-    /// Generally, you shouldn't have to access this directly.
-    pub draw  : &'a Draw<'a>
-}
-
-impl<'a> RenderArgs<'a>{
-    /// Returns a `DrawablesDrawer` for drawing `Drawable`s to the screen
-    pub fn draw_drawables<D: Drawable>(&mut self) -> DrawablesDrawer<D>{
-        self.draw.draw_drawables(self.target)
-    }
-}
-
-/// Macro for easily doing things if particular keys are down
-/// # Examples
-/// Basic usage:
-///
-/// ```ignore
-/// #[macro_use]
-/// extern crate korome;
-///
-/// use korome::{GameLogic, LogicArgs};
-///
-/// struct Logic {
-///     player_y: f32
-/// }
-///
-/// impl GameLogic for Logic{
-///     fn logic(&self, l_args: LogicArgs){
-///         is_down!(l_args;
-///             W, Up => {
-///                 self.player_y -= l_args.delta() as f32
-///             },
-///             S, Down => {
-///                 self.player_y += l_args.delta() as f32
-///             }
-///         );
-///     }
-///     // the rest of implementation omitted
-/// }
-/// ```
-#[macro_export]
-macro_rules! is_down{
-    ( $l_args:ident; $( $( $key:ident ),+ => $b:block ),+ ) => {{
-        $( if $( $l_args.is_down(&glium::glutin::VirtualKeyCode::$key) )||+ $b )+
-    }}
-}
-
-/// A struct to keep your "game" in
-pub struct Game<'a, S, L: FnMut(&mut S, LogicArgs), R: Fn(&S, RenderArgs)> {
-    /// An object that will parsed into the logic and render methods
-    pub shared: S,
-    logic : L,
-    render: R,
-    draw  : Draw<'a>,
-}
-
-impl<'a, L: FnMut(&mut (), LogicArgs), R: Fn(&(), RenderArgs)> Game<'a, (), L, R>{
-    /// Creates a new `Game` with a `Draw` and two closures
-    pub fn new(draw: Draw<'a>, logic: L, render: R) -> Self{
-        Game{
-            shared: (),
-            logic : logic,
-            render: render,
-            draw  : draw,
-        }
-    }
-}
-
-impl<'a, S, L: FnMut(&mut S, LogicArgs), R: Fn(&S, RenderArgs)> Game<'a, S, L, R> {
-    /// Creates a new `Game` with a `Draw`, a shared value, and two closures
-    pub fn with_shared(draw: Draw<'a>, shared: S, logic: L, render: R) -> Self{
-        Game{
-            shared: shared,
-            logic : logic,
-            render: render,
-            draw  : draw,
-        }
-    }
-    /// Runs the `Game` until the window is closed
-    pub fn run_until_closed(mut self){
-        let mut last = time_s();
-        let mut down_keys: HashSet<VirtualKeyCode> = HashSet::new();
-
-        'main: loop {
-            let mut mousepos = (0, 0);
-            let mut keys     = Vec::new();
-
-            for ev in self.draw.get_display().poll_events() {
-                match ev {
-                    Event::Closed => break 'main,
-                    Event::KeyboardInput(es, _, vkc) => match es{
-                        ElementState::Pressed  => {
-                            if let Some(vkc) = vkc{
-                                down_keys.insert( vkc);
-                                keys.push((true , vkc));
-                            }
-                        },
-                        ElementState::Released => {
-                            if let Some(vkc) = vkc{
-                                down_keys.remove(&vkc);
-                                keys.push((false, vkc));
-                            }
-                        }
-                    },
-                    Event::MouseMoved(pos) => mousepos = pos,
-                    _ => ()
-                }
-            }
-
-            let now = time_s();
-
-            let delta = now-last;
-
-            last = now;
-
-            (self.logic)(&mut self.shared, LogicArgs{
-                delta    :  delta,
-                keyevents: &keys,
-                down_keys: &down_keys,
-                mousepos :  mousepos
-            });
-
-            // Do rendering
-            let mut target = self.draw.get_display().draw();
-            target.clear_color(0.0, 0.0, 1.0, 1.0);
-
-            (self.render)(&self.shared, RenderArgs{
-                target: &mut target,
-                draw  : &self.draw
-            });
-
-            target.finish().unwrap()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ mod game;
 mod vector;
 mod settings;
 
-pub use draw::{Draw, Texture, Drawable};
-pub use game::{Game, LogicArgs, RenderArgs};
+pub use draw::{Draw, Texture};
+pub use game::{Game, Sprite, LogicArgs, RenderArgs};
 pub use vector::{Vector2, FloatVector};
 pub use settings::Settings;
 


### PR DESCRIPTION
`Game` now uses two closures instead of a trait.
`Game` can then be parsed a shared variable of any type, that it will pass to the closures by reference.

The code is also re-organised, and all the types in the draw module are now re-exported from the crate - meaning no modules are visible to a user of the crate.

`TextureDrawer` and `DrawablesDrawer` are removed, instead they've been replaced with methods that take all the arguments at the same time.
